### PR TITLE
Fresh install expects filebeat_inputs to be set

### DIFF
--- a/monolith/public.yml
+++ b/monolith/public.yml
@@ -45,6 +45,12 @@ DATADOG_ENABLED: False
 nameservers: []
 internal_domain_name: 'commcarehq.test'
 
+filebeat_inputs:
+  - path: "{{ log_home }}/{{ deploy_env }}_commcare-nginx_error.log"
+    tags:  nginx-error
+  - path: "{{ log_home }}/{{ deploy_env }}-timing.log"
+    tags: nginx-timing
+
 TWO_FACTOR_GATEWAY_ENABLED: False
 
 localsettings:


### PR DESCRIPTION
This seems to be missing from `public.yml` if you follow the instructions for setting up a new monolith, and base your settings on sample-environment/monolith.
