### PR TITLE
Setting letsencrypt_cchq_ssl parameter to True

### DIFF
--- a/monolith/proxy.yml
+++ b/monolith/proxy.yml
@@ -2,3 +2,6 @@ SITE_HOST: 'monolith.commcarehq.test'
 
 special_sites: []
 fake_ssl_cert: True
+# when fake_ssl_cert is False, this parameter set soft links to the Letsencyrpt generated certificates
+# and updates the nginx configuration.
+letsencrypt_cchq_ssl: True 


### PR DESCRIPTION
Adding letsencrypt_cchq_ssl: True in proxy.yml for monolith env as default so that user doesn't have to configure separately while requesting for Free ssl certificates from letsencrypt