### PR TITLE
adding variable for control formplayer deployment

### DIFF
--- a/monolith/meta.yml
+++ b/monolith/meta.yml
@@ -1,4 +1,6 @@
 deploy_env: monolith
 env_monitoring_id: monolith
+# 'all' deploys both commcare and formplayer.
+always_deploy_formplayer: 'all'
 users:
   - admins


### PR DESCRIPTION
If this variable is set to 'all' deploys both Commcare and Formplayer inside the environment. If this variable is not available commcare will be deployed.