### PR TITLE
Enabling daily and weekly backups by default.

### DIFF
--- a/monolith/inventory.ini
+++ b/monolith/inventory.ini
@@ -57,5 +57,6 @@ monolith
 [rabbitmq:children]
 
 [shared_dir_host:children]
+monolith
 
 [riakcs]

--- a/monolith/public.yml
+++ b/monolith/public.yml
@@ -4,13 +4,14 @@ elasticsearch_cluster_name: 'monolith-es'
 elasticsearch_version: 2.4.6
 elasticsearch_download_sha256: 5f7e4bb792917bb7ffc2a5f612dfec87416d54563f795d6a70637befef4cfc6f.
 
-backup_blobdb: False
-backup_postgres: False
+backup_blobdb: True
+backup_postgres: 'plain'
 backup_es_s3: False
-backup_couch: False
+backup_couch: True
 postgres_s3: False
 blobdb_s3: False
 couch_s3: False
+
 
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"


### PR DESCRIPTION
- We are enabling backups by default for new customers. 
Reason for not enabling hourly backups now is the hourly backups PR is not merged yet.