### PR TITLE
Add values required by Kafka and Zookeeper

### DIFF
--- a/monolith/inventory.ini
+++ b/monolith/inventory.ini
@@ -4,6 +4,7 @@ localhost
 [monolith:vars]
 elasticsearch_node_name=es0
 kafka_broker_id=0
+zookeeper_server_id=1
 hostname='monolith'
 #ufw_private_interface=enp0s3
 

--- a/monolith/public.yml
+++ b/monolith/public.yml
@@ -4,6 +4,15 @@ elasticsearch_cluster_name: 'monolith-es'
 elasticsearch_version: 2.4.6
 elasticsearch_download_sha256: 5f7e4bb792917bb7ffc2a5f612dfec87416d54563f795d6a70637befef4cfc6f.
 
+kafka_version: 2.6.1
+kafka_scala_version: 2.13
+kafka_download_sha512: sha512:09ec7a39d0e11494ede7d92cf7dfec5b95c6b0218e3b096b731d85ee8c442469e66aaf369a9c6750399719e515ee1bd372d609d6b232e3358e18aa2b57c90e29
+kafka_inter_broker_protocol_version: 2.6
+kafka_log_message_format_version: 2.6
+
+zookeeper_version: 3.4.9
+zookeeper_download_sha1: sha1:0285717bf5ea87a7a36936bf37851d214a32bb99
+
 backup_blobdb: True
 backup_postgres: 'plain'
 backup_es_s3: False


### PR DESCRIPTION
Adds values required to install Kafka and Zookeeper in new environments.

These values are required [to download Kafka here](https://github.com/dimagi/commcare-cloud/blob/5fe5bb4d9b3fb427cf052fd223b80f910ed2fa08/src/commcare_cloud/ansible/roles/kafka/tasks/main.yml#L20), [to download Zookeeper here](https://github.com/dimagi/commcare-cloud/blob/eb10f2190ecb089a7bea49a2c19f53a062bb86cc/src/commcare_cloud/ansible/roles/zookeeper/tasks/main.yml#L29), and for [Zookeeper config here](https://github.com/dimagi/commcare-cloud/blob/297497263a239ec6c82bea582888c51ad3479b3e/src/commcare_cloud/ansible/roles/zookeeper/templates/zoo.cfg.j2#L25).
