### PR TITLE
Add a setting for `server_admin_email`

### DIFF
--- a/monolith/public.yml
+++ b/monolith/public.yml
@@ -42,6 +42,7 @@ couch_dbs:
     password: "{{ localsettings_private.COUCH_PASSWORD }}"
     is_https: False
 
+server_admin_email: commcarehq-ops+admins@commcarehq.test
 server_email: commcare@monolith.commcarehq.test
 default_from_email: commcare@monolith.commcarehq.test
 root_email: /dev/null


### PR DESCRIPTION
Adding a setting for `server_admin_email` to the sample environment's public.yml file should prompt admins to populate the setting, so that commcare-cloud doesn't fall back to the default value.

Motivated by [this Forum question](https://forum.dimagi.com/t/unable-to-deploy-code-updates-due-to-deploy-fail/9260).
