### PR TITLE
Add couchdb_version to public.yml

### DIFF
--- a/monolith/public.yml
+++ b/monolith/public.yml
@@ -22,7 +22,7 @@ backup_couch: True
 postgres_s3: False
 blobdb_s3: False
 couch_s3: False
-
+couchdb_version: 3.3.1
 
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"


### PR DESCRIPTION
Related to [this PR](https://github.com/dimagi/commcare-cloud/pull/6201).

This change simply adds `couchdb_version` to the sample environment's public.yml file as per [this changelog](https://commcare-cloud.readthedocs.io/en/latest/changelog/0071-upgrade_to_ubuntu_22.04.html); the assumption is that any new project spinning up a new environment from this point on will use Ubuntu 22.04 as per the [prerequisites](https://commcare-cloud.readthedocs.io/en/latest/installation/1-quick-monolith-install.html?#prerequisites).

##### Environments Affected
All newly installed environments.
