### PR TITLE
Set couchdb_version for Ubuntu 22.04

### DIFF
--- a/monolith/public.yml
+++ b/monolith/public.yml
@@ -22,7 +22,7 @@ backup_couch: True
 postgres_s3: False
 blobdb_s3: False
 couch_s3: False
-
+couchdb_version: 3.3.1
 
 couchdb2:
   username: "{{ localsettings_private.COUCH_USERNAME }}"

--- a/monolith/public.yml
+++ b/monolith/public.yml
@@ -35,6 +35,7 @@ couchdb_cluster_settings:
   n: 1
 
 couchdb_use_haproxy: True
+haproxy_version: 2.4
 couch_dbs:
   default:
     host: 127.0.0.1


### PR DESCRIPTION
Sets `couchdb_version` for Ubuntu 22.04.

Applies the change made in https://github.com/dimagi/commcare-cloud/pull/6201 to this repo too.
