### PR TITLE
Update Elasticsearch version

### DIFF
--- a/monolith/public.yml
+++ b/monolith/public.yml
@@ -1,8 +1,8 @@
 elasticsearch_endpoint: '{{ groups.elasticsearch.0 }}'
 elasticsearch_memory: '2048m'
 elasticsearch_cluster_name: 'monolith-es'
-elasticsearch_version: 2.4.6
-elasticsearch_download_sha256: 5f7e4bb792917bb7ffc2a5f612dfec87416d54563f795d6a70637befef4cfc6f.
+elasticsearch_version: 5.6.16
+elasticsearch_download_sha256: 6b035a59337d571ab70cea72cc55225c027ad142fbb07fd8984e54261657c77f.
 
 formplayer_java_version: "{{ java_17_bin_path }}/java"
 
@@ -88,7 +88,7 @@ localsettings:
   COUCH_USERNAME: "{{ localsettings_private.COUCH_USERNAME }}"
   COUCH_STALE_QUERY: 'update_after'
   DEPLOY_MACHINE_NAME: "{{ ansible_hostname }}"
-  ELASTICSEARCH_MAJOR_VERSION: 2
+  ELASTICSEARCH_MAJOR_VERSION: 5
   EMAIL_SMTP_HOST: 'localhost'
   EMAIL_SMTP_PORT: 25
   EMAIL_USE_TLS: no


### PR DESCRIPTION
Implements [changelog 76: Elasticsearch upgrade from 2.4.6 to 5.6.16](https://commcare-cloud.readthedocs.io/en/latest/changelog/0076-upgrade-to-es-5.html) for the sample environment.
